### PR TITLE
fix: add default for github client id

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -8,20 +8,21 @@ variable "location" {
 }
 
 variable "GITHUB_CLIENT_ID" {
-  type = string
+  type    = string
+  default = "627a47faec12864e9953"
 }
 
 variable "GITHUB_CLIENT_SECRET" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "SECRET_KEY" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "DATABASE_NAME" {
-  type = string
+  type    = string
   default = "terraformed-todo-app-sam-db"
 }


### PR DESCRIPTION
Please make sure you are raising this PR against your own repository and not the original. If it says https://github.com/CorndelWithSoftwire in the search bar right now, you are in the wrong place!

Please also don't forget to submit the PR's url to Aptem afterwards (by clicking on the corresponding exercise component, pasting the url in the textbox that appears and then pressing the finish button).